### PR TITLE
chore: use setup-node@v2

### DIFF
--- a/.github/workflows/nodejs-ci-action.yml
+++ b/.github/workflows/nodejs-ci-action.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci


### PR DESCRIPTION
Main OOTB benefit with v2 over v1 is that the action caches Node.js releases and only downloads from nodejs.org on a cache miss, which should be faster (on cache hit) and provide some mitigation if nodejs.org is temporarily unavailable.