### PR TITLE
chore: add the type property to the package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "A summary of what to add when creating a new node module",
   "main": "index.js",
+  "type": "commonjs",
   "scripts": {
     "prepare": "husky install",
     "test": "nyc mocha"


### PR DESCRIPTION
From the node.js docs

> Package authors should include the type field, even in packages where all sources are CommonJS. Being explicit about the type of the package will future-proof the package in case the default type of Node.js ever changes, and it will also make things easier for build tools and loaders to determine how the files in the package should be interpreted.

Adding this to all the nodeshift org modules